### PR TITLE
Update plainstream.py

### DIFF
--- a/plainstream/plainstream.py
+++ b/plainstream/plainstream.py
@@ -41,7 +41,7 @@ def get_text(language,
         if language not in tokenizer:
             tokenizer[language] = Tokenizer(language, normalize=normalize, train_text_gen=train_text)
 
-    dump_url = "http://dumps.wikimedia.org/{}wiki/latest/{}wiki-latest-pages-articles.xml.bz2".format(language, language)
+    dump_url = "https://dumps.wikimedia.org/{}wiki/latest/{}wiki-latest-pages-articles.xml.bz2".format(language, language)
     req = requests.get(dump_url, stream=True)
     with bz2.open(req.raw) as text:
         nbytes = 0


### PR DESCRIPTION
Hi, plainstream needed an s added to the http url that point to the wiki dump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported language options for Wikipedia text retrieval.
  * Improved reliability and security when streaming Wikipedia content by using encrypted connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->